### PR TITLE
Updates for Yii-1.1.16

### DIFF
--- a/EUpdateDialog/EUpdateDialog.php
+++ b/EUpdateDialog/EUpdateDialog.php
@@ -99,7 +99,7 @@ class EUpdateDialog extends CWidget
     
     // Open update dialog the clicking target elements
     $cs->registerScript( 'eupdatedialog', "
-      jQuery( '{$this->target}' ).live( 'click', updateDialogOpen );",
+      jQuery( '{$this->target}' ).on( 'click', updateDialogOpen );",
       CClientScript::POS_END );
     
     // Register additional options for an extension

--- a/EUpdateDialog/assets/EUpdateDialog.js
+++ b/EUpdateDialog/assets/EUpdateDialog.js
@@ -182,8 +182,8 @@ var updateDialog = {
     this.csrfToken = this.getCsrfToken();
     
     // Attach a handler for all submit buttons in dialog content
-    $( '.update-dialog-content input[type=submit]' )
-      .live( 'click', function( e ){
+    $( '.update-dialog-content' )
+		.on('click', 'input[type=submit]', function (e) {
         // Prevent default action
         e.preventDefault();
         
@@ -192,8 +192,8 @@ var updateDialog = {
       });
     
     // Attach a handler for all cancel buttons in dialog content
-    $( '.update-dialog-content .update-dialog-cancel-button' )
-      .live( 'click', function( e ){
+    $( '.update-dialog-content' )
+		.on('click', '.update-dialog-cancel-button', function (e) {
         // Prevent default action
         e.preventDefault();
         


### PR DESCRIPTION
Updates for Yii-1.1.16 (jQuery 1.9+): replaced deprecated live() events
